### PR TITLE
Add graphical abstract display feature

### DIFF
--- a/graphicalAbstract/GraphicalAbstractPlugin.inc.php
+++ b/graphicalAbstract/GraphicalAbstractPlugin.inc.php
@@ -6,6 +6,9 @@ class GraphicalAbstractPlugin extends GenericPlugin {
         if ($success && $this->getEnabled()) {
             HookRegistry::register('Template::Workflow::Submission::Tabs', [$this, 'addGraphicalAbstractTab']);
             HookRegistry::register('LoadComponentHandler', [$this, 'loadTabHandler']);
+
+            // Display the graphical abstract on article and issue pages
+            HookRegistry::register('TemplateManager::display', [$this, 'injectGraphicalAbstract']);
         }
         return $success;
     }
@@ -37,6 +40,37 @@ class GraphicalAbstractPlugin extends GenericPlugin {
             import($this->getPluginPath() . '/GraphicalAbstractTabHandler.inc.php');
             return true;
         }
+        return false;
+    }
+
+    /**
+     * Inject the uploaded graphical abstract into article and issue templates.
+     */
+    public function injectGraphicalAbstract($hookName, $args) {
+        $templateMgr = $args[0];
+        $template = $args[1];
+        $output =& $args[2];
+
+        if ($template === 'frontend/objects/article_summary.tpl') {
+            $article = $templateMgr->getTemplateVars('article');
+            if ($article) {
+                $url = $article->getData('GraphicalAbstract');
+                if ($url) {
+                    $injection = '<div class="graphical_abstract"><img src="' . $url . '" alt="Graphical Abstract"></div>';
+                    $output = preg_replace('/(<\\h[1-6] class="title">.*?<\\/h[1-6]>)/s', "$1" . $injection, $output, 1);
+                }
+            }
+        } elseif ($template === 'frontend/objects/article_details.tpl') {
+            $article = $templateMgr->getTemplateVars('article');
+            if ($article) {
+                $url = $article->getData('GraphicalAbstract');
+                if ($url) {
+                    $injection = '<div class="graphical_abstract"><img src="' . $url . '" alt="Graphical Abstract"></div>';
+                    $output = preg_replace('/(<h1 class="page_title">.*?<\/h1>)/s', "$1" . $injection, $output, 1);
+                }
+            }
+        }
+
         return false;
     }
 }

--- a/graphicalAbstract/README.md
+++ b/graphicalAbstract/README.md
@@ -11,6 +11,7 @@ This plugin adds a **Graphical Abstract** tab to the submission workflow in **Op
 - Validates file type (JPEG/PNG).
 - Available in **English** and **Hindi**.
 - Works with the standard OJS plugin architecture.
+- Displays the graphical abstract below the article title on issue and article pages.
 
 ---
 

--- a/graphicalAbstract/version.xml
+++ b/graphicalAbstract/version.xml
@@ -2,7 +2,7 @@
 <version>
   <application>graphicalAbstract</application>
   <type>plugins.generic</type>
-  <release>1.0.0</release>
-  <date>2025-04-14</date>
+  <release>1.1.0</release>
+  <date>2025-06-09</date>
   <lazyLoad>1</lazyLoad>
 </version>


### PR DESCRIPTION
## Summary
- enable injection of graphical abstracts on article and issue pages
- mention new feature in README
- bump plugin version to 1.1.0

## Testing
- `php -l graphicalAbstract/GraphicalAbstractPlugin.inc.php`
- `php -l graphicalAbstract/GraphicalAbstractTabHandler.inc.php`
- `php -l graphicalAbstract_ojs3.4/graphicalAbstract/GraphicalAbstractPlugin.inc.php`


------
https://chatgpt.com/codex/tasks/task_b_68476605a1c88323bb32cd910ca57f1d